### PR TITLE
Fixing args number in run_

### DIFF
--- a/Plist Binary.py
+++ b/Plist Binary.py
@@ -2,7 +2,7 @@ import sublime, sublime_plugin
 import os
 
 class ToggleBinaryCommand(sublime_plugin.TextCommand):
-  def run_(self, view, args):
+  def run_(self, view, args=None):
 
     fname = self.view.file_name()
     if os.path.splitext(fname)[1].lower() != ".plist":


### PR DESCRIPTION
In ST2, got an error saying that run_() has been given 2 arguments and was waiting for 3. 

I added a default None value to the unused 3rd args to maintain compatibility with ST version which are given 3 args to run_()
